### PR TITLE
show_logo(logo) crashing

### DIFF
--- a/trezor/__init__.py
+++ b/trezor/__init__.py
@@ -20,6 +20,7 @@ from buttons import Buttons
 from layout import Layout
 from display import Display
 from display_buffer import DisplayBuffer
+#from logo import logo                          # uncomment this line if you uncomment 'layout.show_logo(logo)' on line 180
 
 from wallet import Wallet
 from machine import StateMachine


### PR DESCRIPTION
The commented _show_logo(logo)_ when the Cancel button is pressed crashes because _logo_ is undefined
This commit adds a commented _from logo import logo_
