### PR TITLE
fix a crash in electrum get_new_address if n is not a list

### DIFF
--- a/trezor/algo_electrum.py
+++ b/trezor/algo_electrum.py
@@ -31,7 +31,10 @@ class AlgoElectrum(object):
         # Electrum has two branches of keys - standard and change addresses
         # n[0] represent index in branch
         # n[1] == 0 is for standard addresses, n[1] == 1 for change addresses
-        if len(n) != 2:
+        try:
+            if len(n) != 2:
+                raise
+        except:
             raise Exception("n must have exactly two values")
 
         """Publickey(type,n) = Master_public_key + H(n|S|type)*point  """


### PR DESCRIPTION
len(n) crashes if n is not a list/tuple/etc
