### PR TITLE
fix unexpected keyword arg pointy_brackets

### DIFF
--- a/trezor/tools.py
+++ b/trezor/tools.py
@@ -215,7 +215,7 @@ def monkeypatch_google_protobuf_text_format():
 
     _oldPrintFieldValue = google.protobuf.text_format.PrintFieldValue
 
-    def _customPrintFieldValue(field, value, out, indent=0, as_utf8=False, as_one_line=False):
+    def _customPrintFieldValue(field, value, out, indent=0, as_utf8=False, as_one_line=False, pointy_brackets=False, float_format=None):
         if field.type == google.protobuf.descriptor.FieldDescriptor.TYPE_BYTES:
             _oldPrintFieldValue(field, 'hex(%s)' % binascii.hexlify(value), out, indent, as_utf8, as_one_line)
         else:


### PR DESCRIPTION
trezor-emu didn't work for me, because the
monkeypatched PrintFieldValue didn't know the
pointy_brackets keyword argument.

This patch rectifies that. Since it doesn't pass
the pointy brackets parameter on to the originial
PrintFieldValue, this should be safe on old
installations of protobuf (untested).
